### PR TITLE
Add inventory and customer management

### DIFF
--- a/backend/src/controllers/CustomerController.ts
+++ b/backend/src/controllers/CustomerController.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import ListService from "../services/CustomerService/ListService";
+import CreateService from "../services/CustomerService/CreateService";
+import ShowService from "../services/CustomerService/ShowService";
+import UpdateService from "../services/CustomerService/UpdateService";
+import DeleteService from "../services/CustomerService/DeleteService";
+
+export const index = async (req: Request, res: Response): Promise<Response> => {
+  const { searchParam, pageNumber } = req.query as any;
+  const { companyId } = req.user;
+
+  const { customers, count, hasMore } = await ListService({
+    searchParam,
+    pageNumber,
+    companyId
+  });
+
+  return res.json({ customers, count, hasMore });
+};
+
+export const store = async (req: Request, res: Response): Promise<Response> => {
+  const { companyId } = req.user;
+  const customerData = { ...req.body, companyId };
+
+  const customer = await CreateService(customerData);
+
+  return res.status(200).json(customer);
+};
+
+export const show = async (req: Request, res: Response): Promise<Response> => {
+  const { customerId } = req.params;
+  const { companyId } = req.user;
+
+  const customer = await ShowService(customerId, companyId);
+
+  return res.status(200).json(customer);
+};
+
+export const update = async (req: Request, res: Response): Promise<Response> => {
+  const { customerId } = req.params;
+  const { companyId } = req.user;
+  const customerData = req.body;
+
+  const customer = await UpdateService(customerId, customerData, companyId);
+
+  return res.status(200).json(customer);
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+  const { customerId } = req.params;
+  const { companyId } = req.user;
+
+  await DeleteService(customerId, companyId);
+
+  return res.status(200).json({ message: "Customer deleted" });
+};

--- a/backend/src/controllers/ProductController.ts
+++ b/backend/src/controllers/ProductController.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import ListService from "../services/ProductService/ListService";
+import CreateService from "../services/ProductService/CreateService";
+import ShowService from "../services/ProductService/ShowService";
+import UpdateService from "../services/ProductService/UpdateService";
+import DeleteService from "../services/ProductService/DeleteService";
+
+export const index = async (req: Request, res: Response): Promise<Response> => {
+  const { searchParam, pageNumber } = req.query as any;
+  const { companyId } = req.user;
+
+  const { products, count, hasMore } = await ListService({
+    searchParam,
+    pageNumber,
+    companyId
+  });
+
+  return res.json({ products, count, hasMore });
+};
+
+export const store = async (req: Request, res: Response): Promise<Response> => {
+  const { companyId } = req.user;
+  const productData = { ...req.body, companyId };
+
+  const product = await CreateService(productData);
+
+  return res.status(200).json(product);
+};
+
+export const show = async (req: Request, res: Response): Promise<Response> => {
+  const { productId } = req.params;
+  const { companyId } = req.user;
+
+  const product = await ShowService(productId, companyId);
+
+  return res.status(200).json(product);
+};
+
+export const update = async (req: Request, res: Response): Promise<Response> => {
+  const { productId } = req.params;
+  const { companyId } = req.user;
+  const productData = req.body;
+
+  const product = await UpdateService(productId, productData, companyId);
+
+  return res.status(200).json(product);
+};
+
+export const remove = async (req: Request, res: Response): Promise<Response> => {
+  const { productId } = req.params;
+  const { companyId } = req.user;
+
+  await DeleteService(productId, companyId);
+
+  return res.status(200).json({ message: "Product deleted" });
+};

--- a/backend/src/database/index.ts
+++ b/backend/src/database/index.ts
@@ -42,6 +42,8 @@ import { FlowBuilderModel } from "../models/FlowBuilder";
 import { FlowAudioModel } from "../models/FlowAudio";
 import { FlowCampaignModel } from "../models/FlowCampaign";
 import { FlowImgModel } from "../models/FlowImg";
+import Customer from "../models/Customer";
+import Product from "../models/Product";
 
 // eslint-disable-next-line
 const dbConfig = require("../config/database");
@@ -93,6 +95,8 @@ const models = [
   FlowAudioModel,
   FlowCampaignModel,
   FlowImgModel,
+  Customer,
+  Product,
 ];
 
 sequelize.addModels(models);

--- a/backend/src/database/migrations/20250111160000-create-customers.ts
+++ b/backend/src/database/migrations/20250111160000-create-customers.ts
@@ -1,0 +1,49 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.createTable("Customers", {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      phone: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      address: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      companyId: {
+        type: DataTypes.INTEGER,
+        references: { model: "Companies", key: "id" },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+        allowNull: false
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.dropTable("Customers");
+  }
+};

--- a/backend/src/database/migrations/20250111160100-create-products.ts
+++ b/backend/src/database/migrations/20250111160100-create-products.ts
@@ -1,0 +1,49 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.createTable("Products", {
+      id: {
+        type: DataTypes.INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+        allowNull: false
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      description: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      quantity: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
+      price: {
+        type: DataTypes.FLOAT,
+        allowNull: false
+      },
+      companyId: {
+        type: DataTypes.INTEGER,
+        references: { model: "Companies", key: "id" },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+        allowNull: false
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false
+      }
+    });
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.dropTable("Products");
+  }
+};

--- a/backend/src/database/migrations/20250111160200-add-indexes-customer-product.ts
+++ b/backend/src/database/migrations/20250111160200-add-indexes-customer-product.ts
@@ -1,0 +1,21 @@
+import { QueryInterface } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.addIndex("Customers", ["companyId"], {
+        name: "idx_customers_company_id"
+      }),
+      queryInterface.addIndex("Products", ["companyId"], {
+        name: "idx_products_company_id"
+      })
+    ]);
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return Promise.all([
+      queryInterface.removeIndex("Customers", "idx_customers_company_id"),
+      queryInterface.removeIndex("Products", "idx_products_company_id")
+    ]);
+  }
+};

--- a/backend/src/models/Customer.ts
+++ b/backend/src/models/Customer.ts
@@ -1,0 +1,47 @@
+import {
+  Table,
+  Column,
+  CreatedAt,
+  UpdatedAt,
+  Model,
+  PrimaryKey,
+  AutoIncrement,
+  ForeignKey,
+  BelongsTo
+} from "sequelize-typescript";
+import Company from "./Company";
+
+@Table
+class Customer extends Model<Customer> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column
+  id: number;
+
+  @Column
+  name: string;
+
+  @Column
+  email: string;
+
+  @Column
+  phone: string;
+
+  @Column
+  address: string;
+
+  @ForeignKey(() => Company)
+  @Column
+  companyId: number;
+
+  @BelongsTo(() => Company)
+  company: Company;
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+}
+
+export default Customer;

--- a/backend/src/models/Product.ts
+++ b/backend/src/models/Product.ts
@@ -1,0 +1,47 @@
+import {
+  Table,
+  Column,
+  CreatedAt,
+  UpdatedAt,
+  Model,
+  PrimaryKey,
+  AutoIncrement,
+  ForeignKey,
+  BelongsTo
+} from "sequelize-typescript";
+import Company from "./Company";
+
+@Table
+class Product extends Model<Product> {
+  @PrimaryKey
+  @AutoIncrement
+  @Column
+  id: number;
+
+  @Column
+  name: string;
+
+  @Column
+  description: string;
+
+  @Column
+  quantity: number;
+
+  @Column
+  price: number;
+
+  @ForeignKey(() => Company)
+  @Column
+  companyId: number;
+
+  @BelongsTo(() => Company)
+  company: Company;
+
+  @CreatedAt
+  createdAt: Date;
+
+  @UpdatedAt
+  updatedAt: Date;
+}
+
+export default Product;

--- a/backend/src/routes/customerRoutes.ts
+++ b/backend/src/routes/customerRoutes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import isAuth from "../middleware/isAuth";
+import * as CustomerController from "../controllers/CustomerController";
+
+const customerRoutes = express.Router();
+
+customerRoutes.get("/customers", isAuth, CustomerController.index);
+customerRoutes.post("/customers", isAuth, CustomerController.store);
+customerRoutes.get("/customers/:customerId", isAuth, CustomerController.show);
+customerRoutes.put("/customers/:customerId", isAuth, CustomerController.update);
+customerRoutes.delete("/customers/:customerId", isAuth, CustomerController.remove);
+
+export default customerRoutes;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -34,6 +34,8 @@ import forgotsRoutes from "./forgotPasswordRoutes";
 import flowDefaultRoutes from "./flowDefaultRoutes";
 import flowBuilder from "./flowBuilderRoutes";
 import flowCampaignRoutes from "./flowCampaignRoutes";
+import customerRoutes from "./customerRoutes";
+import productRoutes from "./productRoutes";
 const routes = Router();
 
 routes.use(userRoutes);
@@ -68,6 +70,8 @@ routes.use(filesRoutes);
 routes.use(promptRoutes);
 routes.use(queueIntegrationRoutes);
 routes.use(forgotsRoutes);
+routes.use(customerRoutes);
+routes.use(productRoutes);
 
 routes.use(flowDefaultRoutes);
 routes.use(flowBuilder)

--- a/backend/src/routes/productRoutes.ts
+++ b/backend/src/routes/productRoutes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import isAuth from "../middleware/isAuth";
+import * as ProductController from "../controllers/ProductController";
+
+const productRoutes = express.Router();
+
+productRoutes.get("/products", isAuth, ProductController.index);
+productRoutes.post("/products", isAuth, ProductController.store);
+productRoutes.get("/products/:productId", isAuth, ProductController.show);
+productRoutes.put("/products/:productId", isAuth, ProductController.update);
+productRoutes.delete("/products/:productId", isAuth, ProductController.remove);
+
+export default productRoutes;

--- a/backend/src/services/CustomerService/CreateService.ts
+++ b/backend/src/services/CustomerService/CreateService.ts
@@ -1,0 +1,32 @@
+import * as Yup from "yup";
+import AppError from "../../errors/AppError";
+import Customer from "../../models/Customer";
+
+interface CustomerData {
+  name: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+  companyId: number;
+}
+
+const CreateService = async (customerData: CustomerData): Promise<Customer> => {
+  const schema = Yup.object().shape({
+    name: Yup.string().required(),
+    email: Yup.string().email().nullable(),
+    phone: Yup.string().nullable(),
+    address: Yup.string().nullable()
+  });
+
+  try {
+    await schema.validate(customerData);
+  } catch (err: any) {
+    throw new AppError(err.message);
+  }
+
+  const customer = await Customer.create(customerData);
+
+  return customer;
+};
+
+export default CreateService;

--- a/backend/src/services/CustomerService/DeleteService.ts
+++ b/backend/src/services/CustomerService/DeleteService.ts
@@ -1,0 +1,12 @@
+import ShowService from "./ShowService";
+
+const DeleteService = async (
+  customerId: number | string,
+  companyId: number
+): Promise<void> => {
+  const customer = await ShowService(customerId, companyId);
+
+  await customer.destroy();
+};
+
+export default DeleteService;

--- a/backend/src/services/CustomerService/ListService.ts
+++ b/backend/src/services/CustomerService/ListService.ts
@@ -1,0 +1,44 @@
+import { Op, Sequelize } from "sequelize";
+import Customer from "../../models/Customer";
+
+interface Request {
+  companyId: number;
+  searchParam?: string;
+  pageNumber?: string | number;
+}
+
+interface Response {
+  customers: Customer[];
+  count: number;
+  hasMore: boolean;
+}
+
+const ListService = async ({
+  companyId,
+  searchParam = "",
+  pageNumber = "1"
+}: Request): Promise<Response> => {
+  const whereCondition = {
+    name: Sequelize.where(
+      Sequelize.fn("LOWER", Sequelize.col("name")),
+      "LIKE",
+      `%${searchParam.toLowerCase().trim()}%`
+    ),
+    companyId
+  };
+  const limit = 25;
+  const offset = limit * (+pageNumber - 1);
+
+  const { count, rows: customers } = await Customer.findAndCountAll({
+    where: whereCondition,
+    limit,
+    offset,
+    order: [["name", "ASC"]]
+  });
+
+  const hasMore = count > offset + customers.length;
+
+  return { customers, count, hasMore };
+};
+
+export default ListService;

--- a/backend/src/services/CustomerService/ShowService.ts
+++ b/backend/src/services/CustomerService/ShowService.ts
@@ -1,0 +1,17 @@
+import AppError from "../../errors/AppError";
+import Customer from "../../models/Customer";
+
+const ShowService = async (
+  customerId: number | string,
+  companyId: number
+): Promise<Customer> => {
+  const customer = await Customer.findByPk(customerId);
+
+  if (!customer || customer.companyId !== companyId) {
+    throw new AppError("ERR_NO_CUSTOMER_FOUND", 404);
+  }
+
+  return customer;
+};
+
+export default ShowService;

--- a/backend/src/services/CustomerService/UpdateService.ts
+++ b/backend/src/services/CustomerService/UpdateService.ts
@@ -1,0 +1,38 @@
+import * as Yup from "yup";
+import AppError from "../../errors/AppError";
+import Customer from "../../models/Customer";
+import ShowService from "./ShowService";
+
+interface CustomerData {
+  name?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
+}
+
+const UpdateService = async (
+  customerId: number | string,
+  customerData: CustomerData,
+  companyId: number
+): Promise<Customer> => {
+  const schema = Yup.object().shape({
+    name: Yup.string().nullable(),
+    email: Yup.string().email().nullable(),
+    phone: Yup.string().nullable(),
+    address: Yup.string().nullable()
+  });
+
+  try {
+    await schema.validate(customerData);
+  } catch (err: any) {
+    throw new AppError(err.message);
+  }
+
+  const customer = await ShowService(customerId, companyId);
+
+  await customer.update(customerData);
+
+  return customer;
+};
+
+export default UpdateService;

--- a/backend/src/services/ProductService/CreateService.ts
+++ b/backend/src/services/ProductService/CreateService.ts
@@ -1,0 +1,31 @@
+import * as Yup from "yup";
+import AppError from "../../errors/AppError";
+import Product from "../../models/Product";
+
+interface ProductData {
+  name: string;
+  description?: string;
+  quantity: number;
+  price: number;
+  companyId: number;
+}
+
+const CreateService = async (productData: ProductData): Promise<Product> => {
+  const schema = Yup.object().shape({
+    name: Yup.string().required(),
+    quantity: Yup.number().required(),
+    price: Yup.number().required()
+  });
+
+  try {
+    await schema.validate(productData);
+  } catch (err: any) {
+    throw new AppError(err.message);
+  }
+
+  const product = await Product.create(productData);
+
+  return product;
+};
+
+export default CreateService;

--- a/backend/src/services/ProductService/DeleteService.ts
+++ b/backend/src/services/ProductService/DeleteService.ts
@@ -1,0 +1,12 @@
+import ShowService from "./ShowService";
+
+const DeleteService = async (
+  productId: number | string,
+  companyId: number
+): Promise<void> => {
+  const product = await ShowService(productId, companyId);
+
+  await product.destroy();
+};
+
+export default DeleteService;

--- a/backend/src/services/ProductService/ListService.ts
+++ b/backend/src/services/ProductService/ListService.ts
@@ -1,0 +1,44 @@
+import { Op, Sequelize } from "sequelize";
+import Product from "../../models/Product";
+
+interface Request {
+  companyId: number;
+  searchParam?: string;
+  pageNumber?: string | number;
+}
+
+interface Response {
+  products: Product[];
+  count: number;
+  hasMore: boolean;
+}
+
+const ListService = async ({
+  companyId,
+  searchParam = "",
+  pageNumber = "1"
+}: Request): Promise<Response> => {
+  const whereCondition = {
+    name: Sequelize.where(
+      Sequelize.fn("LOWER", Sequelize.col("name")),
+      "LIKE",
+      `%${searchParam.toLowerCase().trim()}%`
+    ),
+    companyId
+  };
+  const limit = 25;
+  const offset = limit * (+pageNumber - 1);
+
+  const { count, rows: products } = await Product.findAndCountAll({
+    where: whereCondition,
+    limit,
+    offset,
+    order: [["name", "ASC"]]
+  });
+
+  const hasMore = count > offset + products.length;
+
+  return { products, count, hasMore };
+};
+
+export default ListService;

--- a/backend/src/services/ProductService/ShowService.ts
+++ b/backend/src/services/ProductService/ShowService.ts
@@ -1,0 +1,17 @@
+import AppError from "../../errors/AppError";
+import Product from "../../models/Product";
+
+const ShowService = async (
+  productId: number | string,
+  companyId: number
+): Promise<Product> => {
+  const product = await Product.findByPk(productId);
+
+  if (!product || product.companyId !== companyId) {
+    throw new AppError("ERR_NO_PRODUCT_FOUND", 404);
+  }
+
+  return product;
+};
+
+export default ShowService;

--- a/backend/src/services/ProductService/UpdateService.ts
+++ b/backend/src/services/ProductService/UpdateService.ts
@@ -1,0 +1,38 @@
+import * as Yup from "yup";
+import AppError from "../../errors/AppError";
+import Product from "../../models/Product";
+import ShowService from "./ShowService";
+
+interface ProductData {
+  name?: string;
+  description?: string;
+  quantity?: number;
+  price?: number;
+}
+
+const UpdateService = async (
+  productId: number | string,
+  productData: ProductData,
+  companyId: number
+): Promise<Product> => {
+  const schema = Yup.object().shape({
+    name: Yup.string().nullable(),
+    quantity: Yup.number().nullable(),
+    price: Yup.number().nullable(),
+    description: Yup.string().nullable()
+  });
+
+  try {
+    await schema.validate(productData);
+  } catch (err: any) {
+    throw new AppError(err.message);
+  }
+
+  const product = await ShowService(productId, companyId);
+
+  await product.update(productData);
+
+  return product;
+};
+
+export default UpdateService;


### PR DESCRIPTION
## Summary
- add `Customer` and `Product` models
- support migrations for new tables
- create CRUD services and controllers for customers and products
- expose `/customers` and `/products` endpoints
- register new routes and models in backend setup

## Testing
- `npm test` *(fails: `sequelize: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6883c1f3120c832bbe7092f64e74d683